### PR TITLE
Try to achieve a more accurate health status

### DIFF
--- a/Symmetrical Tribble/Assets/Scripts/Player/PlayerHealth.cs
+++ b/Symmetrical Tribble/Assets/Scripts/Player/PlayerHealth.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using UnityEngine.UI;
 using System.Collections;
-
+using System;
 
 public class PlayerHealth : MonoBehaviour {
 
@@ -34,10 +34,15 @@ public class PlayerHealth : MonoBehaviour {
     }
 
     HealthLevel[] healthLevel =  new HealthLevel[] {
-        new HealthLevel("Super strong", Color.green), new HealthLevel("Strong", Color.green),
-        new HealthLevel("Ok", Color.blue), new HealthLevel("Injured", Color.cyan),
-        new HealthLevel("Weak", Color.yellow), new HealthLevel("Running on fumes", Color.yellow),
-        new HealthLevel("Like a zombie", Color.red), new HealthLevel("Dying", Color.red)
+        new HealthLevel("Dying", Color.red),
+        new HealthLevel("Like a zombie", new Color((float)0.85 *Color.red.r, Color.red.g,Color.red.b)),
+        new HealthLevel("Running on fumes", Color.yellow),
+        new HealthLevel("Weak", Color.yellow),
+        new HealthLevel("Injured", Color.cyan),
+        new HealthLevel("Ok", Color.blue),
+        new HealthLevel("Strong", new Color(Color.green.r,(float)0.9 * Color.green.g,Color.green.b)),
+        new HealthLevel("Super strong", Color.green),
+        
     };
 
     void Awake() {
@@ -62,17 +67,27 @@ public class PlayerHealth : MonoBehaviour {
     public void TakeDamage(int amount) {
         damaged = true;
         currentHealth -= amount;
-        setHealthText();
-        // playerAudio.Play();
         if(currentHealth <= 0 && !isDead) {
             Death();
         }
+        if(!setHealthText() && !isDead) {
+            Death();
+        }
+        // playerAudio.Play();
     }
 
-    void setHealthText() {
-        int statusIndex = Mathf.Clamp((startingHealth - currentHealth) / healthLevel.Length, 0, healthLevel.Length-1);
+    bool setHealthText() {
+        //note. there are 8 health levels. so 100/8. means they change at 12.5 step sizes.
+        //so if you take damage of 10 and you started with 100 you are still super strong.
+        double healthStatusStepSize = (double)startingHealth / healthLevel.Length;
+        int lostHealthStrength = startingHealth - currentHealth;
+        int healthStepsLost = Convert.ToInt32(((double)lostHealthStrength / healthStatusStepSize));
+
+        int newHeathLevel = (healthLevel.Length - healthStepsLost)-1;
+        int statusIndex = Mathf.Clamp(newHeathLevel, 0, healthLevel.Length-1);
         healthStatusText.text = healthLevel[statusIndex].text;
         healthStatusText.color = healthLevel[statusIndex].color;
+        return newHeathLevel > 0;
     }
 
     void Death() {


### PR DESCRIPTION


there by every time we take damage it is useful to
to just how many of those 8 health statuses we have lost.
to that end i divide the starting health of 100/8. which yields 12.5
so if you take a damage of 10. due to behavior of convent.toint.
converts
10/12.5 into nearest integer of 1. so you lose 1 health status level.

also if you enter dying stage it does not make sense for you remain
alive. you should just die (We dont have a timer at this time.) or else
this could be soemthing that took say 10 seconds.

other changes. re order health statuss.
so higher index means you are higher health level (this make the math
easier to read). also mde the colors green and red a bit different. to
make them different.

see that now strong is super strong are different shades of green.

![image](https://user-images.githubusercontent.com/15373896/49493735-d4595180-f822-11e8-80cb-140fae56c603.png)

@ryanrauch @patrickvinas 
   